### PR TITLE
fix: 1 configuration not found in PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,4 +43,3 @@ runs:
     - uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: /tmp/scan-report.sarif
-        category: cve-bin-tool


### PR DESCRIPTION
previously due to configuration error it was showing `1 configuration not found in PRs` error, but now it works

![image](https://github.com/intel/cve-bin-tool-action/assets/64733912/c1823a26-1a3e-474c-9d98-b7e2e6bdfa8f)
