### PR TITLE
ci: make dependabot weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 


### PR DESCRIPTION
Changing dependabot from daily checks to weekly ones.  this will line up with what we're doing on the main repo, where the number of dependabot version bumps was excessive to the point where it made it hard to write release notes.