### PR TITLE
docs: workflow permissions match openssf guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ on:
     - cron: '20 2 * * *'
 
 permissions:
-  security-events: write
+  contents: read
 
 jobs:
   scan:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: intel/cve-bin-tool-action@main
         with:
@@ -87,11 +89,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  security-events: write
+  contents: read
 
 jobs:
   scan:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: intel/cve-bin-tool-action@main
         with:
@@ -110,11 +114,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  security-events: write
+  contents: read
 
 jobs:
   scan:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Setup node v16 (for build process)
         run: |
@@ -135,13 +141,15 @@ on:
     - cron: '20 2 * * *'
 
 permissions:
-  security-events: write
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   scan:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: write
+      pull-requests: write
     steps:
       - uses: intel/cve-bin-tool-action@main
         with:


### PR DESCRIPTION
Current OpenSSF guidance recommends making the top-level permission read-only and setting permissions per-job (so if someone adds a new job later it doesn't get surprising permissions).