### PR TITLE
fix: add some backwards compatibility

### DIFF
--- a/src/cve_bin_tool.py
+++ b/src/cve_bin_tool.py
@@ -34,6 +34,7 @@ class CVE_BIN_TOOL:
         sbom_format="json",
         sbom_output="SBOM.json",
         vex_file=None,
+        triage_input_file=None,
     ):
         json_data = []
         captured_output = ""
@@ -67,6 +68,10 @@ class CVE_BIN_TOOL:
             if vex_file and Path(vex_file).exists():
                 command.append("--vex-file")
                 command.append(vex_file)
+            elif triage_input_file and Path(triage_input_file).exists():
+                # Backwards compatibility with old arg name
+                command.append("--vex-file")
+                command.append(triage_input_file)
             if filter_triage:
                 command.append("--filter-triage")
             captured_output += subprocess.run(

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -76,6 +76,11 @@ def main():
         help="Filter vulnerabilities based on triage data.",
         required=False,
     )
+    parser.add_argument(
+        "--triage-input-file",
+        help="(Deprecated) Use --vex-file instead.",
+        required=False,
+    )
 
     args = parser.parse_args()
     # workaround for args from action.yml being passed as string instead of boolean
@@ -91,6 +96,10 @@ def main():
 
     cve_bin_tool = CVE_BIN_TOOL()
     cve_bin_tool.update_db(args.nvd_api_key)
+
+    # backwards compatibility for folk still using triage-input-file instead of vex-file
+    if args.triage_input_file and not args.vex_file:
+        args.vex_file = args.triage_input_file
 
     if not args.sbom_type:
         args.sbom_type = "spdx"


### PR DESCRIPTION
We changed from "triage_input_file" to "vex_file" in #110 but didn't leave backwards compatibility shims in for folk using the old tag.